### PR TITLE
Optimize Makefile :

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,54 +1,56 @@
 #CC = gcc
+#RM = rm
+#AR = ar
 LN = ln
 INSTALL = install
-RM = rm
 MKDIR = mkdir
+
+DIR_BUILD = .build
+prefix = /usr/local
 
 PPFLAGS = -MT $@ -MMD -MP -MF $(DIR_BUILD)/$*.d
 
 CFLAGS_LOCAL = -Wall -g -std=gnu99 -coverage
 CFLAGS_LOCAL += $(CFLAGS)
 
-prefix = /usr/local
-
-DIR_BUILD = .build
+VALGRIND = valgrind --leak-check=full --show-leak-kinds=all
 
 APP_SOURCE = abi.c
 APP_OBJECT = abi.o
+APP = abi
 
 LIB_SOURCES = source/abi_bf.c \
         source/abi_tokens.c
-LIB_OBJECTS = $(patsubst %.c, %.o, $(notdir $(LIB_SOURCES)))
-LIBVERSION = 0.0.1
-LIBNAME = abi
-LIB_SO_ABI = lib$(LIBNAME).so.$(LIBVERSION)
-
-APP = abi
+LIB_OBJECTS = $(patsubst %.c, %.o, $(LIB_SOURCES))
+LIB_VERSION = 0.0.1
+LIB_NAME = abi
+LIB_SO = lib$(LIB_NAME).so.$(LIB_VERSION)
+LIB_A = lib$(LIB_NAME).a.$(LIB_VERSION)
 
 DEPFILES = $(patsubst %.o, %.d, $(addprefix $(DIR_BUILD)/, $(LIB_OBJECTS)) $(DIR_BUILD)/$(APP_OBJECT))
 
-# set c sources search path
-vpath %.c $(sort $(dir $(LIB_SOURCES)))
-
 .PHONY : all clean install uninstall test
+
 all : $(DIR_BUILD) $(DIR_BUILD)/$(APP)
 
-$(DIR_BUILD)/$(APP) : $(DIR_BUILD)/$(APP_OBJECT) $(DIR_BUILD)/$(LIB_SO_ABI) | Makefile
-	$(CC) $(CFLAGS_LOCAL) -o $@ $< -L$(shell pwd)/$(DIR_BUILD) -l$(LIBNAME)
+$(DIR_BUILD)/$(APP) : $(DIR_BUILD)/$(APP_OBJECT) $(DIR_BUILD)/$(LIB_SO) $(DIR_BUILD)/$(LIB_A) | Makefile
+	$(CC) $(CFLAGS_LOCAL) -o $@ $< -L$(shell pwd)/$(DIR_BUILD) -l$(LIB_NAME)
 
-$(DIR_BUILD)/$(APP_OBJECT) : $(APP_SOURCE) | Makefile 
-	$(CC) -MT $@ -MMD -MP -MF $*.d $(CFLAGS_LOCAL) -c $< -o $@
-
-$(DIR_BUILD)/$(LIB_SO_ABI) : $(addprefix $(DIR_BUILD)/, $(LIB_OBJECTS)) | Makefile
+$(DIR_BUILD)/$(LIB_SO) : $(addprefix $(DIR_BUILD)/, $(LIB_OBJECTS)) | Makefile
 	$(CC) $(CFLAGS_LOCAL) -shared -o $@ $(addprefix $(DIR_BUILD)/, $(LIB_OBJECTS))
-	$(LN) -sf $(shell pwd)/$(DIR_BUILD)/$(LIB_SO_ABI) $(DIR_BUILD)/lib$(LIBNAME).so
+	$(LN) -sf $(shell pwd)/$(DIR_BUILD)/$(LIB_SO) $(DIR_BUILD)/lib$(LIB_NAME).so
 
-$(DIR_BUILD)/%.o : %.c | Makefile
+$(DIR_BUILD)/$(LIB_A) : $(addprefix $(DIR_BUILD)/, $(LIB_OBJECTS)) | Makefile
+	$(AR) $(ARFLAGS) $@ $^
+	$(LN) -sf $(shell pwd)/$(DIR_BUILD)/$(LIB_A) $(DIR_BUILD)/lib$(LIB_NAME).a
+
+$(addprefix $(DIR_BUILD)/, $(APP_OBJECT)) : $(DIR_BUILD)/%.o : %.c
+	$(MKDIR) -p $(@D)
+	$(CC) $(PPFLAGS) $(CFLAGS_LOCAL) -c $< -o $@
+
+$(addprefix $(DIR_BUILD)/, $(LIB_OBJECTS)) : $(DIR_BUILD)/%.o : %.c
+	$(MKDIR) -p $(@D)
 	$(CC) $(PPFLAGS) $(CFLAGS_LOCAL) -fPIC -c $< -o $@
-
-#$(OBJECTS): $(DIR_BUILD)/%.o: %.c
-	#$(MKDIR) -p $(@D)
-	#$(CC) $(PPFLAGS) $(CFLAGS_LOCAL) -c $< -o $@
 
 $(DIR_BUILD)/%.d : ;
 .PRECIOUS : $(DIR_BUILD)/%.d
@@ -58,23 +60,27 @@ $(DIR_BUILD) :
 
 install : all
 	$(INSTALL) -d "$(prefix)/lib"
-	$(INSTALL) "$(DIR_BUILD)/$(LIB_SO_ABI)" "$(prefix)/lib"
-	$(LN) -sf "$(prefix)/lib/$(LIB_SO_ABI)" "$(prefix)/lib/lib$(LIBNAME).so"
+	$(INSTALL) "$(DIR_BUILD)/$(LIB_SO)" "$(prefix)/lib"
+	$(LN) -sf "$(prefix)/lib/$(LIB_SO)" "$(prefix)/lib/lib$(LIB_NAME).so"
+	$(INSTALL) "$(DIR_BUILD)/$(LIB_A)" "$(prefix)/lib"
+	$(LN) -sf "$(prefix)/lib/$(LIB_A)" "$(prefix)/lib/lib$(LIB_NAME).a"
 	$(INSTALL) -d "$(prefix)/bin"
 	$(INSTALL) "$(DIR_BUILD)/$(APP)" "$(prefix)/bin"
 
 uninstall : 
-	$(RM) -f "$(prefix)/lib/$(LIB_SO_ABI)"
-	$(RM) -f "$(prefix)/lib/lib$(LIBNAME).so"
+	$(RM) -f "$(prefix)/lib/$(LIB_SO)"
+	$(RM) -f "$(prefix)/lib/lib$(LIB_NAME).so"
+	$(RM) -f "$(prefix)/lib/$(LIB_A)"
+	$(RM) -f "$(prefix)/lib/lib$(LIB_NAME).a"
 	$(RM) -f "$(prefix)/bin/$(APP)"
 
 test :
-	@valgrind --leak-check=full --show-leak-kinds=all echo 0 | $(APP) -f examples/196.bf
-	@valgrind --leak-check=full --show-leak-kinds=all echo 9 | $(APP) -f examples/196.bf
-	@valgrind --leak-check=full --show-leak-kinds=all echo 'hello world' | $(APP) -f examples/echo.bf
-	@valgrind --leak-check=full --show-leak-kinds=all $(APP) -f examples/ascii.bf
-	@valgrind --leak-check=full --show-leak-kinds=all $(APP) -f examples/hello.bf
-	@valgrind --leak-check=full --show-leak-kinds=all $(APP) -f examples/test.bf
+	$(VALGRIND) echo 0 | $(APP) -f examples/196.bf
+	$(VALGRIND) echo 9 | $(APP) -f examples/196.bf
+	$(VALGRIND) echo 'hello world' | $(APP) -f examples/echo.bf
+	$(VALGRIND) $(APP) -f examples/ascii.bf
+	$(VALGRIND) $(APP) -f examples/hello.bf
+	$(VALGRIND) $(APP) -f examples/test.bf
 
 clean : 
 	$(RM) -rf $(DIR_BUILD)


### PR DESCRIPTION
  1.  Generate static library and install/uninstall.
  2.  Generate all intermediate files to subdirectory instead of direct build directory.